### PR TITLE
Added nesting to Example.lhs

### DIFF
--- a/example/Test/Framework/Example.lhs
+++ b/example/Test/Framework/Example.lhs
@@ -65,9 +65,11 @@ tests = [
                 testProperty "sort3" prop_sort3
             ],
         testGroup "Sorting Group 2" [
-                testProperty "sort4" prop_sort4,
-                testProperty "sort5" prop_sort5,
-                testProperty "sort6" prop_sort6,
+                testGroup "Nested Group 1" [
+                       testProperty "sort4" prop_sort4,
+                       testProperty "sort5" prop_sort5,
+                       testProperty "sort6" prop_sort6
+                     ],
                 testCase "sort7" test_sort7,
                 testCase "sort8" test_sort8
             ]


### PR DESCRIPTION
In order to have the example project output XML that fully differentiates the styles, I added a nested testGroup call in the test definitions.
