### PR TITLE
Preserve layout of HUnit error messages (close #11)

### DIFF
--- a/hunit/Test/Framework/Providers/HUnit.hs
+++ b/hunit/Test/Framework/Providers/HUnit.hs
@@ -47,7 +47,7 @@ data TestCaseResult = TestCasePassed
 instance Show TestCaseResult where
     show result = case result of
         TestCasePassed         -> "OK"
-        TestCaseFailed message -> "Failed: " ++ message
+        TestCaseFailed message -> message
         TestCaseError message  -> "ERROR: " ++ message
 
 testCaseSucceeded :: TestCaseResult -> Bool


### PR DESCRIPTION
e.g. output

```
expected: "1010110001001011"
 but got: "1010100001001011"
```

instead of

```
Failed: expected: "1010110001001011"
 but got: "1010100001001011"
```
