### PR TITLE
Only colorize output when stdout is connected to a  terminal

### DIFF
--- a/core/Test/Framework/Runners/Options.hs
+++ b/core/Test/Framework/Runners/Options.hs
@@ -6,6 +6,7 @@ import Test.Framework.Runners.TestPattern
 
 import Data.Monoid
 
+data ColorMode = ColorAuto | ColorNever | ColorAlways
 
 type RunnerOptions = RunnerOptions' Maybe
 type CompleteRunnerOptions = RunnerOptions' K
@@ -15,7 +16,7 @@ data RunnerOptions' f = RunnerOptions {
         ropt_test_patterns :: f [TestPattern],
         ropt_xml_output :: f (Maybe FilePath),
         ropt_xml_nested :: f Bool,
-        ropt_plain_output :: f Bool,
+        ropt_color_mode :: f ColorMode,
         ropt_hide_successes :: f Bool
     }
 
@@ -26,7 +27,7 @@ instance Monoid (RunnerOptions' Maybe) where
             ropt_test_patterns = Nothing,
             ropt_xml_output = Nothing,
             ropt_xml_nested = Nothing,
-            ropt_plain_output = Nothing,
+            ropt_color_mode = Nothing,
             ropt_hide_successes = Nothing
         }
 
@@ -36,6 +37,6 @@ instance Monoid (RunnerOptions' Maybe) where
             ropt_test_patterns = mappendBy ropt_test_patterns ro1 ro2,
             ropt_xml_output = mappendBy ropt_xml_output ro1 ro2,
             ropt_xml_nested = getLast (mappendBy (Last . ropt_xml_nested) ro1 ro2),
-            ropt_plain_output = getLast (mappendBy (Last . ropt_plain_output) ro1 ro2),
+            ropt_color_mode = getLast (mappendBy (Last . ropt_color_mode) ro1 ro2),
             ropt_hide_successes = getLast (mappendBy (Last . ropt_hide_successes) ro1 ro2)
         }


### PR DESCRIPTION
--color can be used to force colorized output (e.g. useful with less -R)
