### PR TITLE
Added --list-tests option to Console.hs

### DIFF
--- a/core/Test/Framework/Runners/Console.hs
+++ b/core/Test/Framework/Runners/Console.hs
@@ -132,7 +132,7 @@ defaultMainWithOpts tests ropts = do
     let ropts' = completeRunnerOptions ropts
     
     when (unK$ ropt_list_only ropts') $ do 
-      putStrLn "FINISH ME -- LIST AVAILABLE TESTS!!"
+      putStr $ listTests tests
       exitSuccess
     
     -- Get a lazy list of the test results, as executed in parallel
@@ -156,6 +156,18 @@ defaultMainWithOpts tests ropts = do
     exitWith $ if ts_no_failures test_statistics'
                then ExitSuccess
                else ExitFailure 1
+
+-- | Print out a list of available tests.
+listTests :: [Test] -> String
+listTests tests = "\ntest-framework: All available tests:\n"++
+                  "====================================\n"++ 
+                  concat (map (++"\n") (concatMap (showTest "") tests))
+  where 
+    showTest :: String -> Test -> [String]
+    showTest path (Test name _testlike)    = ["  "++path ++ name]
+    showTest path (TestGroup name tests)   = concatMap (showTest (path++":"++name)) tests
+    showTest path (PlusTestOptions _ test) = showTest path test
+    showTest path (BuildTest build)        = []
 
 
 completeRunnerOptions :: RunnerOptions -> CompleteRunnerOptions

--- a/core/Test/Framework/Runners/Console.hs
+++ b/core/Test/Framework/Runners/Console.hs
@@ -14,6 +14,7 @@ import qualified Test.Framework.Runners.XML as XML
 import Test.Framework.Seed
 import Test.Framework.Utilities
 
+import Control.Monad (when)
 import System.Console.GetOpt
 import System.Environment
 import System.Exit
@@ -64,6 +65,9 @@ optionsDescription = [
         Option [] ["no-timeout"]
             (NoArg (mempty { ropt_test_options = Just (mempty { topt_timeout = Just Nothing }) }))
             "specifies that tests should be run without a timeout, by default",
+        Option ['l'] ["list-tests"]
+            (NoArg (mempty { ropt_list_only = Just True }))
+            "list available tests but don't run any; useful to guide subsequent --select-tests",
         Option ['t'] ["select-tests"]
             (ReqArg (\t -> mempty { ropt_test_patterns = Just [read t] }) "TEST-PATTERN")
             "only tests that match at least one glob pattern given by an instance of this argument will be run",
@@ -127,6 +131,10 @@ defaultMainWithOpts :: [Test] -> RunnerOptions -> IO ()
 defaultMainWithOpts tests ropts = do
     let ropts' = completeRunnerOptions ropts
     
+    when (unK$ ropt_list_only ropts') $ do 
+      putStrLn "FINISH ME -- LIST AVAILABLE TESTS!!"
+      exitSuccess
+    
     -- Get a lazy list of the test results, as executed in parallel
     running_tests <- runTests ropts' tests
 
@@ -158,5 +166,6 @@ completeRunnerOptions ro = RunnerOptions {
             ropt_xml_output = K $ ropt_xml_output ro `orElse` Nothing,
             ropt_xml_nested = K $ ropt_xml_nested ro `orElse` False,
             ropt_color_mode = K $ ropt_color_mode ro `orElse` ColorAuto,
-            ropt_hide_successes = K $ ropt_hide_successes ro `orElse` False
+            ropt_hide_successes = K $ ropt_hide_successes ro `orElse` False,
+            ropt_list_only      = K $ ropt_list_only      ro `orElse` False
         }

--- a/core/Test/Framework/Runners/Options.hs
+++ b/core/Test/Framework/Runners/Options.hs
@@ -17,7 +17,8 @@ data RunnerOptions' f = RunnerOptions {
         ropt_xml_output :: f (Maybe FilePath),
         ropt_xml_nested :: f Bool,
         ropt_color_mode :: f ColorMode,
-        ropt_hide_successes :: f Bool
+        ropt_hide_successes :: f Bool,
+        ropt_list_only  :: f Bool
     }
 
 instance Monoid (RunnerOptions' Maybe) where
@@ -28,7 +29,8 @@ instance Monoid (RunnerOptions' Maybe) where
             ropt_xml_output = Nothing,
             ropt_xml_nested = Nothing,
             ropt_color_mode = Nothing,
-            ropt_hide_successes = Nothing
+            ropt_hide_successes = Nothing,
+            ropt_list_only      = Nothing
         }
 
     mappend ro1 ro2 = RunnerOptions {
@@ -38,5 +40,6 @@ instance Monoid (RunnerOptions' Maybe) where
             ropt_xml_output = mappendBy ropt_xml_output ro1 ro2,
             ropt_xml_nested = getLast (mappendBy (Last . ropt_xml_nested) ro1 ro2),
             ropt_color_mode = getLast (mappendBy (Last . ropt_color_mode) ro1 ro2),
-            ropt_hide_successes = getLast (mappendBy (Last . ropt_hide_successes) ro1 ro2)
+            ropt_hide_successes = getLast (mappendBy (Last . ropt_hide_successes) ro1 ro2),
+            ropt_list_only      = getLast (mappendBy (Last . ropt_list_only)      ro1 ro2)
         }


### PR DESCRIPTION
The problem is that when the code is paged out of my brain I can't remember what the test names are to pass to "--select-tests".  Rather than dig around in the source code I find it easier to just have a --list-tests option.  What do you think?
