### PR TITLE
Remove upper bound from QuickCheck dependency

### DIFF
--- a/quickcheck2/test-framework-quickcheck2.cabal
+++ b/quickcheck2/test-framework-quickcheck2.cabal
@@ -22,7 +22,7 @@ Flag Base3
 Library
         Exposed-Modules:        Test.Framework.Providers.QuickCheck2
 
-        Build-Depends:          test-framework >= 0.6, QuickCheck >= 2.4 && < 2.5, extensible-exceptions >= 0.1.1 && < 0.2.0
+        Build-Depends:          test-framework >= 0.6, QuickCheck >= 2.4, extensible-exceptions >= 0.1.1 && < 0.2.0
         if flag(base3)
                 Build-Depends:          base >= 3 && < 4, random >= 1
         else


### PR DESCRIPTION
QuickCheck 2.5 is out now, and test-framework-quickcheck2 would be compatible if it wasn't for the restrictive upper bounds. Rather than widen those bounds, I've chosen to remove them.
