### PR TITLE
Fix typo in test pattern description

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,7 +208,7 @@ $ ghc-pkg hide QuickCheck-2.1.0.1
            both examples would be matched by <code>group/**1</code>.  A leading slash matches the beginning of the test path; for example, <code>/test*</code>
            matches <code>test1</code> but not <code>group/test1</code>.</p></li>
 
-        <p>A test will be run if it matches <i>any</i> of the patterns supplied with <code>-s</code>.</p>
+        <p>A test will be run if it matches <i>any</i> of the patterns supplied with <code>-t</code>.</p>
         
         <h2>Documentation</h2>
         <p>Haddock documentation is available at Hackage:</p>


### PR DESCRIPTION
`-s` is the test size argument, most likely this was just a typo.
