### PR TITLE
Export optionsDescription

### DIFF
--- a/core/Test/Framework/Runners/Console.hs
+++ b/core/Test/Framework/Runners/Console.hs
@@ -1,6 +1,6 @@
 module Test.Framework.Runners.Console (
         defaultMain, defaultMainWithArgs, defaultMainWithOpts,
-        interpretArgs, interpretArgsOrExit
+        optionsDescription, interpretArgs, interpretArgsOrExit
     ) where
 
 import Test.Framework.Core


### PR DESCRIPTION
Hi Max,

I would like to use `test-framework` in a test suite where I need to specify some additional command line arguments. Moreover, I would like to use [cmdtheline](http://hackage.haskell.org/package/cmdtheline) to handle the command line processing.

I've written [a patch](https://github.com/eli-frey/cmdtheline/pull/19) for cmdtheline that provides an adapter for a list of `OptDescrs`.

If `test-framework` would export it's options then I can use both packages together like in the following:

``` haskell
import Data.Functor                     ( (<$>) )
import Data.Maybe                       ( catMaybes )
import Data.Monoid                      ( mconcat )
import System.Console.CmdTheLine        ( Term, run, defTI )
import System.Console.CmdTheLine.GetOpt ( optDescrsTerm )
import Test.Framework                   ( defaultMainWithOpts, optionsDescription )

main :: IO ()
main = run (term, defTI)

term :: Term (IO ())
term = defaultMainWithOpts [] . mconcat . catMaybes <$>
         optDescrsTerm optionsDescription
```

Running it:

```
$ ./test --help
NAME

SYNOPSIS
       b, [OPTION]...

OPTIONS
       --maximum-generated-tests=NUMBER, -a NUMBER
           how many automated tests something like QuickCheck should try, by
           default

       --maximum-test-depth=NUMBER, -d NUMBER
           to what depth something like SmallCheck should test the properties,
           by default

       --threads=NUMBER, -j NUMBER
           number of threads to use to run tests

       --list-tests, -l
           list available tests but don't run any; useful to guide subsequent
           --select-tests

       --timeout=NUMBER, -o NUMBER
           how many seconds a test should be run for before giving up, by
           default

       --maximum-test-size=NUMBER, -s NUMBER
           to what size something like QuickCheck should test the properties,
           by default

       --select-tests=TEST-PATTERN, -t TEST-PATTERN
           only tests that match at least one glob pattern given by an
           instance of this argument will be run

       --color
           use ANSI terminal features to display the test run

       --help
           show this help message

       --help[=FMT] (default=pager)
           Show this help in format FMT (pager, plain, or groff).

       --hide-successes
           hide sucessful tests, and only show failures

       --jxml=FILE
           write a JUnit XML summary of the output to FILE

       --jxml-nested
           use nested testsuites to represent groups in JUnit XML (not
           standards compliant)

       --maximum-unsuitable-generated-tests=NUMBER
           how many unsuitable candidate tests something like QuickCheck
           should endure before giving up, by default

       --no-timeout
           specifies that tests should be run without a timeout, by default

       --plain
           do not use any ANSI terminal features to display the test run

       --test-seed=NUMBER|random
           default seed for test random number generator
```
