### PR TITLE
Bump base dependency lower bound

### DIFF
--- a/core/test-framework.cabal
+++ b/core/test-framework.cabal
@@ -13,10 +13,6 @@ Maintainer:          Max Bolingbroke <batterseapower@hotmail.com>
 Homepage:            http://batterseapower.github.com/test-framework/
 Build-Type:          Simple
 
-Flag SplitBase
-        Description:    Choose the new smaller, split-up base package
-        Default:        True
-
 Flag Tests
         Description:    Build the tests
         Default:        False
@@ -49,13 +45,10 @@ Library
                                 Test.Framework.Utilities
 
         Build-Depends:          ansi-terminal >= 0.4.0, ansi-wl-pprint >= 0.5.1,
+                                base >= 4.3 && < 5, random >= 1.0, containers >= 0.1,
                                 regex-posix >= 0.72, extensible-exceptions >= 0.1.1,
                                 old-locale >= 1.0, time >= 1.1.2,
                                 xml >= 1.3.5, hostname >= 1.0
-        if flag(splitBase)
-                Build-Depends:          base >= 3 && < 5, random >= 1.0, containers >= 0.1
-        else
-                Build-Depends:          base < 3
 
         Extensions:             CPP
                                 PatternGuards
@@ -79,15 +72,12 @@ Executable test-framework-tests
                 Buildable:              False
         else
                 Build-Depends:          HUnit >= 1.2, QuickCheck >= 2.3 && < 2.5,
+                                        base >= 4.3 && < 5, random >= 1.0, containers >= 0.1,
                                         ansi-terminal >= 0.4.0, ansi-wl-pprint >= 0.5.1,
                                         regex-posix >= 0.72, extensible-exceptions >= 0.1.1,
                                         old-locale >= 1.0, time >= 1.1.2,
                                         xml >= 1.3.5, hostname >= 1.0,
                                         libxml >= 0.1.1, bytestring >= 0.9
-                if flag(splitBase)
-                        Build-Depends:          base >= 3 && < 5, random >= 1.0, containers >= 0.1
-                else
-                        Build-Depends:          base < 3
 
                 Extensions:             CPP
                                         PatternGuards


### PR DESCRIPTION
This also means that use of the extensible-exceptions library is now redundant, since base >= 4 provides that functionality, but I won't do the work involved with that unless you're happy with this change.
