### PR TITLE
removed upper bound on quickcheck in test-framework-quickcheck2

### DIFF
--- a/quickcheck2/test-framework-quickcheck2.cabal
+++ b/quickcheck2/test-framework-quickcheck2.cabal
@@ -22,7 +22,7 @@ Flag Base3
 Library
         Exposed-Modules:        Test.Framework.Providers.QuickCheck2
 
-        Build-Depends:          test-framework >= 0.7.1, QuickCheck >= 2.4 && < 2.6, extensible-exceptions >= 0.1.1 && < 0.2.0
+        Build-Depends:          test-framework >= 0.7.1, QuickCheck >= 2.4, extensible-exceptions >= 0.1.1 && < 0.2.0
         if flag(base3)
                 Build-Depends:          base >= 3 && < 4, random >= 1
         else


### PR DESCRIPTION
The upper bound on quickcheck < 2.6 was causing cabal to resolve back to test-framework-quickcheck2-0.2.4 (or thereabouts) which no longer builds.

This change fixes that, but without knowing why the upperbound was introduced, I'm not sure if removing it will cause other problems.
