### PR TITLE
Allow QuickCheck-2.6 (standard with Haskell Platform 2013.2.0.0)

### DIFF
--- a/quickcheck2/test-framework-quickcheck2.cabal
+++ b/quickcheck2/test-framework-quickcheck2.cabal
@@ -1,5 +1,5 @@
 Name:                test-framework-quickcheck2
-Version:             0.3.0.1
+Version:             0.3.0.2
 Cabal-Version:       >= 1.2.3
 Category:            Testing
 Synopsis:            QuickCheck2 support for the test-framework package.
@@ -22,7 +22,7 @@ Flag Base3
 Library
         Exposed-Modules:        Test.Framework.Providers.QuickCheck2
 
-        Build-Depends:          test-framework >= 0.7.1, QuickCheck >= 2.4 && < 2.6, extensible-exceptions >= 0.1.1 && < 0.2.0
+        Build-Depends:          test-framework >= 0.7.1, QuickCheck >= 2.4 && < 2.7, extensible-exceptions >= 0.1.1 && < 0.2.0
         if flag(base3)
                 Build-Depends:          base >= 3 && < 4, random >= 1
         else


### PR DESCRIPTION
Without this, tests built with "ghc --make" may fail compilations, as they use both QuickCheck-2.6  and an older version for test-framework-quickcheck2 and then instances defined for the new quickcheck don't work with the old one..
