### PR TITLE
Making the library compile with GHC 7.7 and base 4.7

### DIFF
--- a/core/Test/Framework/Runners/Console.hs
+++ b/core/Test/Framework/Runners/Console.hs
@@ -24,14 +24,6 @@ import System.IO
 import Data.Monoid
 
 
-instance Functor OptDescr where
-    fmap f (Option a b arg_descr c) = Option a b (fmap f arg_descr) c
-
-instance Functor ArgDescr where
-    fmap f (NoArg a) = NoArg (f a)
-    fmap f (ReqArg g s) = ReqArg (f . g) s
-    fmap f (OptArg g s) = OptArg (f . g) s
-
 -- | @Nothing@ signifies that usage information should be displayed.
 -- @Just@ simply gives us the contribution to overall options by the command line option.
 type SuppliedRunnerOptions = Maybe RunnerOptions

--- a/core/Test/Framework/Runners/Console.hs
+++ b/core/Test/Framework/Runners/Console.hs
@@ -23,6 +23,15 @@ import System.IO
 
 import Data.Monoid
 
+#if !MIN_VERSION_base(4,7,0)
+instance Functor OptDescr where
+    fmap f (Option a b arg_descr c) = Option a b (fmap f arg_descr) c
+
+instance Functor ArgDescr where
+    fmap f (NoArg a) = NoArg (f a)
+    fmap f (ReqArg g s) = ReqArg (f . g) s
+    fmap f (OptArg g s) = OptArg (f . g) s
+#endif
 
 -- | @Nothing@ signifies that usage information should be displayed.
 -- @Just@ simply gives us the contribution to overall options by the command line option.


### PR DESCRIPTION
Functor instances for ArgDescr and OptDescr are now defined in base 4.7
