### PR TITLE
Unhide the Test.Framework.Runners.Console.TestPattern module

### DIFF
--- a/core/test-framework.cabal
+++ b/core/test-framework.cabal
@@ -24,6 +24,7 @@ Library
                                 Test.Framework.Providers.API
                                 Test.Framework.Runners.Console
                                 Test.Framework.Runners.Options
+                                Test.Framework.Runners.TestPattern
                                 Test.Framework.Runners.API
                                 Test.Framework.Seed
 
@@ -38,7 +39,6 @@ Library
                                 Test.Framework.Runners.Core
                                 Test.Framework.Runners.Processors
                                 Test.Framework.Runners.Statistics
-                                Test.Framework.Runners.TestPattern
                                 Test.Framework.Runners.ThreadPool
                                 Test.Framework.Runners.TimedConsumption
                                 Test.Framework.Runners.XML.JUnitWriter


### PR DESCRIPTION
Doing this allows the user to make full use of the parsed RunnerOptions obtained with interpretArgs from the Test.Framework.Runners.Console module.

This is especially useful with dynamically generated tests; knowing that a test would be filtered anyway due to the command-line parameters allows the user to skip its generation altogether.

Without this patch, although the RunnerOptions ropt_test_patterns property is available, the TestPattern definition and the testPatternMatches function are hidden from the user, rendering the feature unusable except by Test.Framework itself.
