### PR TITLE
Correcting JUnit XML output to conform Jenkins XSD

### DIFF
--- a/core/Test/Framework/Runners/XML/JUnitWriter.hs
+++ b/core/Test/Framework/Runners/XML/JUnitWriter.hs
@@ -58,7 +58,7 @@ toXml nested runDesc = unode "testsuite" (attrs, morph_cases (tests runDesc))
              , ("name",      id . suiteName)
              , ("tests",     show . testCount)
              , ("time",      show . time)
-             , ("timeStamp", fromMaybe "" . timeStamp)
+             , ("timestamp", fromMaybe "" . timeStamp)
              , ("id",        fromMaybe "" . runId)
              , ("package",   fromMaybe "" . package)
              ]


### PR DESCRIPTION
JUnit XML output, as understood by Jenkins, requires attribute
"timestamp" and not "timeStamp".

References:
- https://svn.jenkins-ci.org/trunk/hudson/dtkit/dtkit-format/dtkit-junit-model/src/main/resources/com/thalesgroup/dtkit/junit/model/xsd/junit-5.xsd
- http://svn.apache.org/repos/asf/ant/core/trunk/src/main/org/apache/tools/ant/taskdefs/optional/junit/XMLJUnitResultFormatter.java
- http://svn.apache.org/repos/asf/ant/core/trunk/src/main/org/apache/tools/ant/taskdefs/optional/junit/XMLConstants.java
