### PR TITLE
Bumped the (strict) upper bound on the QuickCheck dependency from 2.6 to 2.7

### DIFF
--- a/quickcheck2/test-framework-quickcheck2.cabal
+++ b/quickcheck2/test-framework-quickcheck2.cabal
@@ -22,7 +22,7 @@ Flag Base3
 Library
         Exposed-Modules:        Test.Framework.Providers.QuickCheck2
 
-        Build-Depends:          test-framework >= 0.7.1, QuickCheck >= 2.4 && < 2.6, extensible-exceptions >= 0.1.1 && < 0.2.0
+        Build-Depends:          test-framework >= 0.7.1, QuickCheck >= 2.4 && < 2.7, extensible-exceptions >= 0.1.1 && < 0.2.0
         if flag(base3)
                 Build-Depends:          base >= 3 && < 4, random >= 1
         else


### PR DESCRIPTION
This patch bumps the (exclusive) upper version bound on QuickCheck from 2.6 to 2.7.  Please accept this patch because at this time test-framework-quickcheck2 is not reliably cabal-installable as it requires that an older version of QuickCheck be installed than that in that latest Haskell Platform.
