### PR TITLE
Relax the version restriction on the QuickCheck dependency

### DIFF
--- a/quickcheck2/test-framework-quickcheck2.cabal
+++ b/quickcheck2/test-framework-quickcheck2.cabal
@@ -22,7 +22,7 @@ Flag Base3
 Library
         Exposed-Modules:        Test.Framework.Providers.QuickCheck2
 
-        Build-Depends:          test-framework >= 0.7.1, QuickCheck >= 2.4 && < 2.6, extensible-exceptions >= 0.1.1 && < 0.2.0
+        Build-Depends:          test-framework >= 0.7.1, QuickCheck >= 2.4 &&, extensible-exceptions >= 0.1.1 && < 0.2.0
         if flag(base3)
                 Build-Depends:          base >= 3 && < 4, random >= 1
         else


### PR DESCRIPTION
Relax the dependency on QuickCheck, as the < 2.6 restriction is causing problems now that the Haskell Platform bundles version 2.6.
This is particularly bad in the context of the FPComplete IDE where we don't have access to the package database and cannot install customised forks.
