### PR TITLE
GitHub Pages Doesn't Support HTTPS

### DIFF
--- a/core/test-framework.cabal
+++ b/core/test-framework.cabal
@@ -10,7 +10,7 @@ License:             BSD3
 License-File:        LICENSE
 Author:              Max Bolingbroke <batterseapower@hotmail.com>
 Maintainer:          Libraries List <libraries@haskell.org>
-Homepage:            https://batterseapower.github.io/test-framework/
+Homepage:            http://batterseapower.github.io/test-framework/
 Bug-Reports:         https://github.com/haskell/test-framework/issues/
 Build-Type:          Simple
 

--- a/quickcheck2/test-framework-quickcheck2.cabal
+++ b/quickcheck2/test-framework-quickcheck2.cabal
@@ -7,7 +7,7 @@ License:             BSD3
 License-File:        LICENSE
 Author:              Max Bolingbroke <batterseapower@hotmail.com>
 Maintainer:          Haskell Libraries <libraries@haskell.org>
-Homepage:            https://batterseapower.github.io/test-framework/
+Homepage:            http://batterseapower.github.io/test-framework/
 Bug-Reports:         https://github.com/haskell/test-framework/
 Build-Type:          Simple
 Description:         QuickCheck2 support for the test-framework package.


### PR DESCRIPTION
Prevents browser warnings when someone clicks on the link to this
project's GitHub page.
